### PR TITLE
Update UsageTrackingJob.php

### DIFF
--- a/lib/Cron/UsageTrackingJob.php
+++ b/lib/Cron/UsageTrackingJob.php
@@ -14,21 +14,21 @@ class UsageTrackingJob extends TimedJob {
     /** @var UsageListener */
     protected $usageListener;
 
-    public function __construct(ITimeFactory $time = null, UsageListener $usageListener = null) {
+    public function __construct(?ITimeFactory $time = null, ?UsageListener $usageListener = null) {
         // When called from background job system, instantiate dependencies
         if ($time === null) {
             $time = Server::get(ITimeFactory::class);
         }
-        
+
         parent::__construct($time);
-        
+
         // When called from background job system, get UsageListener using the server container
         if ($usageListener === null) {
             $this->usageListener = Server::get(UsageListener::class);
         } else {
             $this->usageListener = $usageListener;
         }
-        
+
         // Run every 5 minutes
         $this->setInterval(5 * 60);
     }


### PR DESCRIPTION
Constructor parameters $time and $usageListener are now explicitly marked as nullable using ?Type.

This change ensures compatibility with PHP 8.2+ and eliminates the deprecation warning.


Fix 

https://github.com/Bruce-Matrix/transfer_quota_monitor/issues/1